### PR TITLE
fix: hermes unknown command line argument '-fenable-tdz'

### DIFF
--- a/lib/agents/hermes.js
+++ b/lib/agents/hermes.js
@@ -32,7 +32,7 @@ class HermesAgent extends ConsoleAgent {
       this.args.unshift('-non-strict');
     }
 
-    this.args.unshift('-Xintl', '-enable-eval', '-fenable-tdz');
+    this.args.unshift('-Xintl', '-enable-eval');
 
     // There is currently no flag for supporting modules in Hermes
     // if (options.module && this.args[0] !== '-m') {


### PR DESCRIPTION
- fix: https://github.com/tc39/eshost/issues/125
- ref: https://github.com/facebook/hermes/issues/839
  - `-Xenable-tdz` unsupported

before

```sh
➜  eshost -e "42"
#### engine262
42

#### hermes

hermes: Unknown command line argument '-fenable-tdz'.  Try: '/Users/leo/.esvu/bin/hermes -help'

#### javascriptcore
42

#### spidermonkey
42

#### v8
42

#### xs
42
```

after

```sh
➜  eshost git:(fix-hermes-unknown-cl-arg-fenable-tdz) eshost -e "42"
#### engine262
42

#### hermes
42

#### javascriptcore
42

#### spidermonkey
42

#### v8
42

#### xs
42
```


info

```console
➜  npm list -g
/Users/leo/.nvm/versions/node/v22.13.1/lib
├── corepack@0.30.0
├── eshost-cli@9.0.0
├── esvu@1.2.16
└── npm@10.9.2
```

```console
➜  hermes-cli-darwin-v0.12.0 ./hermes -help-hidden | grep tdz
  -Xenable-tdz                        - UNSUPPORTED: Enable TDZ checks for let/const
```

```console
➜  hermes-cli-darwin-v0.13.0 ./hermes -help-hidden | grep tdz
[Nothing to see here]
```

cc @gibson042 @tmikov